### PR TITLE
[FIX] Improves spectral PSF degradation

### DIFF
--- a/hazel/model.py
+++ b/hazel/model.py
@@ -1364,9 +1364,9 @@ class Model(object):
             if (v.psf_spectral is not None):                
                 for i in range(4):
                     if (perturbation):
-                        v.stokes_perturbed[i,:] = scipy.signal.convolve(v.stokes_perturbed[i,:], v.psf_spectral, mode='same', method='auto')
+                        v.stokes_perturbed[i,:] = scipy.ndimage.convolve(v.stokes_perturbed[i,:], v.psf_spectral, mode='nearest')
                     else:
-                        v.stokes[i,:] = scipy.signal.convolve(v.stokes[i,:], v.psf_spectral, mode='same', method='auto')
+                        v.stokes[i,:] = scipy.ndimage.convolve(v.stokes[i,:], v.psf_spectral, mode='nearest')
             
             if (v.interpolate_to_lr):
                 for i in range(4):

--- a/hazel/spectrum.py
+++ b/hazel/spectrum.py
@@ -59,7 +59,7 @@ class Spectrum(object):
                 self.psf_spectral = f(self.wavelength_axis)
             else:
                 sigma = float(instrumental_profile) * np.mean(self.wavelength_axis) / c.to('km/s').value                
-                self.psf_spectral = np.exp(-(self.wavelength_axis - self.wavelength_axis[n//2-1])**2 / sigma**2)
+                self.psf_spectral = np.exp(-(self.wavelength_axis - self.wavelength_axis[n//2-1])**2 / 2*(sigma**2))
 
             self.psf_spectral /= np.sum(self.psf_spectral)
                 

--- a/hazel/spectrum.py
+++ b/hazel/spectrum.py
@@ -58,8 +58,8 @@ class Spectrum(object):
                 f = interpolate.interp1d(tmp[:,0] + self.wavelength_axis[n//2-1], tmp[:,1], kind='cubic', fill_value=0.0, bounds_error=False)                
                 self.psf_spectral = f(self.wavelength_axis)
             else:
-                sigma = float(instrumental_profile) * np.mean(self.wavelength_axis) / c.to('km/s').value                
-                self.psf_spectral = np.exp(-(self.wavelength_axis - self.wavelength_axis[n//2-1])**2 / 2*(sigma**2))
+                sigma = float(instrumental_profile) * np.mean(self.wavelength_axis) / c.to('km/s').value
+                self.psf_spectral = np.exp(-(self.wavelength_axis - self.wavelength_axis[n//2-1])**2 / (2*(sigma**2)))
 
             self.psf_spectral /= np.sum(self.psf_spectral)
                 


### PR DESCRIPTION
1) signal.convolve only works for 0 padding. ndimage.convolve allow for using the edges for the convolution (needed for Stokes I).
2) Missing value "2" in the definition of the Gaussian